### PR TITLE
Allow for home.arpa. per RFC8375.

### DIFF
--- a/src/dns2mdns.c
+++ b/src/dns2mdns.c
@@ -261,7 +261,7 @@ _service_callback(DNSServiceRef service __unused,
     {
     case kDNSServiceType_PTR:
       /* Inverse PTRs are typically unique (and lack SRV/TXT of interest). */
-      if (_string_endswith(name, ".arpa."))
+      if (_string_endswith(name, ".arpa.") && !(_string_endswith(name, ".home.arpa.")))
         probably_cf = true;
       else
         {
@@ -360,7 +360,7 @@ bool b_query_start(io_query ioq)
        * Look at the request. Either it ends with one of the domains we
        * already have, or it ends with arpa, or we ignore it.
        */
-      if (_string_endswith(qb, ".arpa."))
+      if (_string_endswith(qb, ".arpa.") && !(_string_endswith(qb, ".home.arpa.")))
         {
           ifo = NULL;
           q->use_query_name_in_reply = true;


### PR DESCRIPTION
Patched my OpenWRT server build with the changes in this PR. Tested successfully:

```lang-sh
...
Fri May 22 01:14:58 2020 daemon.debug ohybridproxy[9876]: adding query imac.home.arpa./28 to 0x7f2d12e2ee40
Fri May 22 01:14:58 2020 daemon.debug ohybridproxy[9876]: _rewrite_domain 'imac.home.arpa.'->12 bytes (home.arpa.->local.)
Fri May 22 01:14:58 2020 daemon.debug ohybridproxy[9876]: rewrote -> 'imac.local.'
Fri May 22 01:14:58 2020 daemon.debug ohybridproxy[9876]: DNSServiceQueryRecord imac.local. @ 3
Fri May 22 01:14:58 2020 daemon.debug ohybridproxy[9876]: adding rr imac.home.arpa./28 (16 bytes, 120 ttl)
Fri May 22 01:14:58 2020 daemon.debug ohybridproxy[9876]: _rewrite_domain 'iMac.local.'->16 bytes (local.->home.arpa.)
Fri May 22 01:14:58 2020 daemon.debug ohybridproxy[9876]: rewrote -> 'iMac.home.arpa.'
Fri May 22 01:14:58 2020 daemon.debug ohybridproxy[9876]: adding rr iMac.home.arpa. / 28.1 ttl 120 (16 rrdata)
Fri May 22 01:14:58 2020 daemon.debug ohybridproxy[9876]: io_query_stop imac.home.arpa.
Fri May 22 01:14:58 2020 daemon.debug ohybridproxy[9876]: cache_entry_completed imac.home.arpa./28 - ttl:120 seconds
Fri May 22 01:14:58 2020 daemon.debug ohybridproxy[9876]: io_req_stop
Fri May 22 01:15:06 2020 daemon.debug ohybridproxy[9876]: Received 55 bytes via UDP
Fri May 22 01:15:06 2020 daemon.debug ohybridproxy[9876]:  .. found valid cache for imac.home.arpa./28
Fri May 22 01:15:12 2020 daemon.debug ohybridproxy[9876]: Received 55 bytes via UDP
Fri May 22 01:15:12 2020 daemon.debug ohybridproxy[9876]:  .. new query imac.home.arpa./1
Fri May 22 01:15:12 2020 daemon.debug ohybridproxy[9876]: adding query imac.home.arpa./1 to 0x7f2d12e2ee40
Fri May 22 01:15:12 2020 daemon.debug ohybridproxy[9876]: _rewrite_domain 'imac.home.arpa.'->12 bytes (home.arpa.->local.)
Fri May 22 01:15:12 2020 daemon.debug ohybridproxy[9876]: rewrote -> 'imac.local.'
Fri May 22 01:15:12 2020 daemon.debug ohybridproxy[9876]: DNSServiceQueryRecord imac.local. @ 3
Fri May 22 01:15:12 2020 daemon.debug ohybridproxy[9876]: adding rr imac.home.arpa./1 (4 bytes, 120 ttl)
Fri May 22 01:15:12 2020 daemon.debug ohybridproxy[9876]: _rewrite_domain 'iMac.local.'->16 bytes (local.->home.arpa.)
Fri May 22 01:15:12 2020 daemon.debug ohybridproxy[9876]: rewrote -> 'iMac.home.arpa.'
Fri May 22 01:15:12 2020 daemon.debug ohybridproxy[9876]: adding rr iMac.home.arpa. / 1.1 ttl 120 (4 rrdata)
Fri May 22 01:15:12 2020 daemon.debug ohybridproxy[9876]: io_query_stop imac.home.arpa.
Fri May 22 01:15:12 2020 daemon.debug ohybridproxy[9876]: cache_entry_completed imac.home.arpa./1 - ttl:120 seconds
Fri May 22 01:15:12 2020 daemon.debug ohybridproxy[9876]: io_req_stop
Fri May 22 01:16:13 2020 daemon.debug ohybridproxy[9876]: Received 55 bytes via UDP
Fri May 22 01:16:13 2020 daemon.debug ohybridproxy[9876]:  .. found valid cache for imac.home.arpa./1
Fri May 22 01:16:18 2020 daemon.debug ohybridproxy[9876]: Received 55 bytes via UDP
Fri May 22 01:16:18 2020 daemon.debug ohybridproxy[9876]:  .. found valid cache for imac.home.arpa./28
``` 

Welcome additional `home.arpa.` users to test and confirm as well.